### PR TITLE
Remove synom

### DIFF
--- a/crates/wasm-bindgen-macro/Cargo.toml
+++ b/crates/wasm-bindgen-macro/Cargo.toml
@@ -8,7 +8,6 @@ proc-macro = true
 
 [dependencies]
 syn = { git = 'https://github.com/dtolnay/syn', features = ['full'] }
-synom = { git = 'https://github.com/dtolnay/syn' }
 quote = { git = 'https://github.com/dtolnay/quote' }
 proc-macro2 = { version = "0.1", features = ["unstable"] }
 serde_json = "1"

--- a/crates/wasm-bindgen-macro/src/lib.rs
+++ b/crates/wasm-bindgen-macro/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(proc_macro)]
 
 extern crate syn;
-extern crate synom;
 #[macro_use]
 extern crate quote;
 extern crate proc_macro;
@@ -393,19 +392,19 @@ impl ToTokens for Receiver {
             Receiver::FreeFunction(name) => name.to_tokens(tokens),
             Receiver::StructFunction(s, name) => {
                 s.to_tokens(tokens);
-                syn::tokens::Colon2::default().to_tokens(tokens);
+                syn::token::Colon2::default().to_tokens(tokens);
                 name.to_tokens(tokens);
             }
             Receiver::StructMethod(_, mutable, name) => {
                 (my_quote! { me }).to_tokens(tokens);
-                syn::tokens::Dot::default().to_tokens(tokens);
+                syn::token::Dot::default().to_tokens(tokens);
                 if mutable {
                     syn::Ident::from("borrow_mut").to_tokens(tokens);
                 } else {
                     syn::Ident::from("borrow").to_tokens(tokens);
                 }
                 tokens.append_delimited("(", Default::default(), |_| ());
-                syn::tokens::Dot::default().to_tokens(tokens);
+                syn::token::Dot::default().to_tokens(tokens);
                 name.to_tokens(tokens);
             }
         }


### PR DESCRIPTION
- Removed `synom` due to merge into `syn` in  https://github.com/dtolnay/syn/commit/c5ab8c6b9fb7bf3f303abac2086485f272a73ebf
- `syn::tokens` is now `syn::token` :unamused: 

@alexcrichton I would additionally lock down the version of `syn` so that this stuff doesn't happen again, but I'd leave that up to you.

 Fixes #1