### PR TITLE
Really fix bindings link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,9 @@ wasm_bindgen! {
 ```
 
 The generated JS bindings for this invocation of the macro [look like
-this](bindings). You can view them in action like so:
+this][bindings]. You can view them in action like so:
 
 [bindings]: https://gist.github.com/b7dfa241208ee858d5473c406225080f
-
 
 ```html
 <html>


### PR DESCRIPTION
Sorry, the previous commit hid the reference correctly but had the wrong link.

Turns out that you still have to use square brackets for reference style links, but the reference can't be part of the block.

Markdown is a mess.