### PR TITLE
WasmRefCell into_inner with 'unsafe'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,8 +337,8 @@ pub mod __rt {
             }
         }
 
-        pub unsafe fn into_inner(self) -> T {
-            self.value.into_inner()
+        pub fn into_inner(self) -> T {
+            unsafe { self.value.into_inner() }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ pub mod __rt {
             }
         }
 
-        pub fn into_inner(self) -> T {
+        pub unsafe fn into_inner(self) -> T {
             self.value.into_inner()
         }
     }


### PR DESCRIPTION
This change wraps the `into_inner` call with `unsafe`. `UnsafeCell into_inner` is unsafe, thus it seems the `into_inner` in WasmRefCell needs to be unsafe as well. Relates to my issue here - #10 