### PR TITLE
Don't panic on unsupported exports

### DIFF
--- a/crates/wasm-bindgen-cli-support/src/wasm2es6js.rs
+++ b/crates/wasm-bindgen-cli-support/src/wasm2es6js.rs
@@ -57,10 +57,10 @@ impl Output {
                         continue
                     }
                     Internal::Table(_) => {
-                        panic!("wasm exports a table which isn't supported yet");
+                        continue
                     }
                     Internal::Global(_) => {
-                        panic!("wasm exports globals which aren't supported yet");
+                        continue
                     }
                 };
 
@@ -145,10 +145,10 @@ impl Output {
                         continue
                     }
                     Internal::Table(_) => {
-                        panic!("wasm exports a table which isn't supported yet");
+                        continue
                     }
                     Internal::Global(_) => {
-                        panic!("wasm exports globals which aren't supported yet");
+                        continue
                     }
                 };
 


### PR DESCRIPTION
It's most likely safe for us to skip exports that we don't yet support.  Doing nothing will at least not hurt in those cases.

This is needed because recent `rustc` has started exporting a `__web_table` table (not sure what it's used for though)