### PR TITLE
C-Style Enums

### DIFF
--- a/crates/wasm-bindgen-cli-support/src/js.rs
+++ b/crates/wasm-bindgen-cli-support/src/js.rs
@@ -978,6 +978,9 @@ impl<'a, 'b> SubContext<'a, 'b> {
         for f in self.program.imports.iter() {
             self.generate_import(f);
         }
+        for e in self.program.enums.iter() {
+            self.generate_enum(e);
+        }
     }
 
     pub fn generate_export(&mut self, export: &shared::Export) {
@@ -1423,6 +1426,19 @@ impl<'a, 'b> SubContext<'a, 'b> {
         self.cx.globals.push_str("export ");
         self.cx.globals.push_str(&dst);
         self.cx.globals.push_str("\n");
+    }
+
+    pub fn generate_enum(&mut self, enum_: &shared::Enum) {
+        let mut variants = String::new();
+
+        let mut value = 0;
+        for variant in enum_.variants.iter() {
+            variants.push_str(&format!("{}:{},", variant.name, value));
+            value = value + 1;
+        }
+        self.cx.globals.push_str(&format!("export const {} = {{", enum_.name));
+        self.cx.globals.push_str(&variants);
+        self.cx.globals.push_str("}\n");
     }
 }
 

--- a/crates/wasm-bindgen-cli-support/src/js.rs
+++ b/crates/wasm-bindgen-cli-support/src/js.rs
@@ -1051,7 +1051,8 @@ impl<'a, 'b> SubContext<'a, 'b> {
                 passed_args.push_str(arg);
             };
             match *arg {
-                shared::TYPE_NUMBER => {
+                shared::TYPE_ENUM | shared::TYPE_NUMBER => {
+                    // TODO: TS for Enum
                     dst_ts.push_str(": number");
                     if self.cx.config.debug {
                         self.cx.expose_assert_num();

--- a/crates/wasm-bindgen-cli-support/src/js.rs
+++ b/crates/wasm-bindgen-cli-support/src/js.rs
@@ -1434,10 +1434,8 @@ impl<'a, 'b> SubContext<'a, 'b> {
     pub fn generate_enum(&mut self, enum_: &shared::Enum) {
         let mut variants = String::new();
 
-        let mut value = 0;
         for variant in enum_.variants.iter() {
-            variants.push_str(&format!("{}:{},", variant.name, value));
-            value = value + 1;
+            variants.push_str(&format!("{}:{},", variant.name, variant.value));
         }
         self.cx.globals.push_str(&format!("export const {} = {{", enum_.name));
         self.cx.globals.push_str(&variants);

--- a/crates/wasm-bindgen-cli-support/src/js.rs
+++ b/crates/wasm-bindgen-cli-support/src/js.rs
@@ -1054,15 +1054,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                 passed_args.push_str(arg);
             };
             match *arg {
-                shared::TYPE_ENUM => {
-                    dst_ts.push_str(&format!(": {}", "any"));
-                    if self.cx.config.debug {
-                        self.cx.expose_assert_num();
-                        arg_conversions.push_str(&format!("_assertNum({});\n", name));
-                    }
-                    pass(&name)
-                }
-                shared::TYPE_NUMBER => {
+                shared::TYPE_ENUM | shared::TYPE_NUMBER => {
                     dst_ts.push_str(": number");
                     if self.cx.config.debug {
                         self.cx.expose_assert_num();
@@ -1168,7 +1160,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                 format!("return ret;")
             }
             Some(shared::TYPE_ENUM) => {
-                dst_ts.push_str(": any");
+                dst_ts.push_str(": number");
                 format!("return ret;")
             }
             Some(shared::TYPE_NUMBER) => {

--- a/crates/wasm-bindgen-macro/src/ast.rs
+++ b/crates/wasm-bindgen-macro/src/ast.rs
@@ -333,12 +333,11 @@ impl Program {
                         .filter_map(|e| e.class)
                         .chain(self.structs.iter().map(|s| s.name))
                         .collect::<BTreeSet<_>>();
-
                     a.list(&names, |s, a| {
                         let val = shared::name_to_descriptor(s.as_ref());
                         a.fields(&[
                             ("descriptor", &|a| a.char(val)),
-                            ("name", &|a| a.str(&s.as_ref()))
+                            ("name", &|a| a.str(s.as_ref()))
                         ]);
                     })
                 }),
@@ -671,9 +670,7 @@ impl Enum {
         a.fields(&[
                  ("name", &|a| a.str(self.name.as_ref())),
                  ("variants", &|a| a.list(&self.variants, |v, a| {
-                     a.fields(&[
-                              ("name", &|a| a.str(v.as_ref()))
-                     ])
+                     a.fields(&[("name", &|a| a.str(v.as_ref()))])
                  })),
         ]);
     }

--- a/crates/wasm-bindgen-macro/src/ast.rs
+++ b/crates/wasm-bindgen-macro/src/ast.rs
@@ -206,7 +206,7 @@ impl Program {
         }
     }
 
-    pub fn push_enum(&mut self, item: syn::ItemEnum, opts: BindgenAttrs) {
+    pub fn push_enum(&mut self, item: syn::ItemEnum, _opts: BindgenAttrs) {
         match item.vis {
             syn::Visibility::Public(_) => {}
             _ => panic!("only public enums are allowed"),
@@ -329,22 +329,16 @@ impl Program {
                 ("imports", &|a| a.list(&self.imports, Import::wbg_literal)),
                 ("enums", &|a| a.list(&self.enums, Enum::wbg_literal)),
                 ("custom_type_names", &|a| {
-                    let struct_descriptors = self.exports.iter()
+                    let names = self.exports.iter()
                         .filter_map(|e| e.class)
                         .chain(self.structs.iter().map(|s| s.name))
-                        .map(|n| {
-                            let val = shared::name_to_descriptor(n.as_ref());
-                            (val, n.to_string())
-                        });
-                    let enum_descriptors = self.enums.iter().map(|e| {
-                            (shared::TYPE_ENUM, e.name.to_string())
-                        });
-                    let descriptors = struct_descriptors.chain(enum_descriptors).collect::<BTreeSet<_>>();
+                        .collect::<BTreeSet<_>>();
 
-                    a.list(&descriptors, |s, a| {
+                    a.list(&names, |s, a| {
+                        let val = shared::name_to_descriptor(s.as_ref());
                         a.fields(&[
-                            ("descriptor", &|a| a.char(s.0)),
-                            ("name", &|a| a.str(&s.1))
+                            ("descriptor", &|a| a.char(val)),
+                            ("name", &|a| a.str(&s.as_ref()))
                         ]);
                     })
                 }),

--- a/crates/wasm-bindgen-macro/src/ast.rs
+++ b/crates/wasm-bindgen-macro/src/ast.rs
@@ -212,8 +212,7 @@ impl Program {
             _ => panic!("only public enums are allowed"),
         }
 
-        let mut i = 0;
-        let variants = item.variants.iter().map(|ref v| {
+        let variants = item.variants.iter().enumerate().map(|(i, v)| {
             match v.fields {
                 syn::Fields::Unit => (),
                 _ => panic!("Only C-Style enums allowed")
@@ -225,11 +224,10 @@ impl Program {
                     }
                     int_lit.value() as u32
                 },
-                None => i,
+                None => i as u32,
                 _ => panic!("Enums may only have number literal values")
             };
 
-            i = i + 1;
             (v.ident, value)
         }).collect();
         self.enums.push(Enum {

--- a/crates/wasm-bindgen-macro/src/ast.rs
+++ b/crates/wasm-bindgen-macro/src/ast.rs
@@ -49,7 +49,8 @@ pub struct Struct {
 }
 
 pub struct Enum {
-    pub name: syn::Ident
+    pub name: syn::Ident,
+    pub variants: Vec<syn::Ident>
 }
 
 pub enum Type {
@@ -211,20 +212,17 @@ impl Program {
             _ => panic!("only public enums are allowed"),
         }
 
-        let all_fields_unit = item.variants.iter().all(|ref v| {
+        let variants = item.variants.iter().map(|ref v| {
             match v.fields {
-                syn::Fields::Unit => true,
-                _ => false
+                syn::Fields::Unit => (),
+                _ => panic!("Only C-Style enums allowed")
             }
+            v.ident
+        }).collect();
+        self.enums.push(Enum {
+            name: item.ident,
+            variants
         });
-        if all_fields_unit {
-            self.enums.push(Enum {
-                name: item.ident
-            });
-
-        } else {
-            panic!("Only C-Style enums allowed")
-        }
     }
 
     pub fn push_foreign_fn(&mut self,

--- a/crates/wasm-bindgen-shared/src/lib.rs
+++ b/crates/wasm-bindgen-shared/src/lib.rs
@@ -8,6 +8,7 @@ use std::hash::{Hash, Hasher};
 #[derive(Deserialize)]
 pub struct Program {
     pub exports: Vec<Export>,
+    pub enums: Vec<Enum>,
     pub imports: Vec<Import>,
     pub custom_type_names: Vec<CustomTypeName>,
 }
@@ -30,6 +31,17 @@ pub struct Export {
     pub class: Option<String>,
     pub method: bool,
     pub function: Function,
+}
+
+#[derive(Deserialize)]
+pub struct Enum {
+    pub name: String,
+    pub variants: Vec<EnumVariant>,
+}
+
+#[derive(Deserialize)]
+pub struct EnumVariant {
+    pub name: String
 }
 
 #[derive(Deserialize)]

--- a/crates/wasm-bindgen-shared/src/lib.rs
+++ b/crates/wasm-bindgen-shared/src/lib.rs
@@ -77,6 +77,7 @@ pub fn mangled_import_name(struct_: Option<&str>, f: &str) -> String {
 
 pub type Type = char;
 
+pub const TYPE_ENUM: char = '\u{5d}';
 pub const TYPE_NUMBER: char = '\u{5e}';
 pub const TYPE_BORROWED_STR: char = '\u{5f}';
 pub const TYPE_STRING: char = '\u{60}';

--- a/crates/wasm-bindgen-shared/src/lib.rs
+++ b/crates/wasm-bindgen-shared/src/lib.rs
@@ -41,7 +41,8 @@ pub struct Enum {
 
 #[derive(Deserialize)]
 pub struct EnumVariant {
-    pub name: String
+    pub name: String,
+    pub value: u32
 }
 
 #[derive(Deserialize)]

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -42,3 +42,46 @@ fn c_style_enum() {
         "#)
         .test();
 }
+
+#[test]
+fn c_style_enum_with_custom_values() {
+    test_support::project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub enum Color {
+                Green = 21,
+                Yellow = 34,
+                Red,
+            }
+
+            #[no_mangle]
+            #[wasm_bindgen]
+            pub extern fn cycle(color: Color) -> Color {
+                match color {
+                    Color::Green => Color::Yellow,
+                    Color::Yellow => Color::Red,
+                    Color::Red => Color::Green,
+                }
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.strictEqual(wasm.Color.Green, 21);
+                assert.strictEqual(wasm.Color.Yellow, 34);
+                assert.strictEqual(wasm.Color.Red, 2);
+                assert.strictEqual(Object.keys(wasm.Color).length, 3);
+
+                assert.strictEqual(wasm.cycle(wasm.Color.Green), wasm.Color.Yellow);
+            }
+        "#)
+        .test();
+}

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,0 +1,44 @@
+extern crate test_support;
+
+#[test]
+fn c_style_enum() {
+    test_support::project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub enum Color {
+                Green,
+                Yellow,
+                Red,
+            }
+
+            #[no_mangle]
+            #[wasm_bindgen]
+            pub extern fn cycle(color: Color) -> Color {
+                match color {
+                    Color::Green => Color::Yellow,
+                    Color::Yellow => Color::Red,
+                    Color::Red => Color::Green,
+                }
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.strictEqual(wasm.Color.Green, 0);
+                assert.strictEqual(wasm.Color.Yellow, 1);
+                assert.strictEqual(wasm.Color.Red, 2);
+                assert.strictEqual(Object.keys(wasm.Color).length, 3);
+
+                assert.strictEqual(wasm.cycle(wasm.Color.Green), wasm.Color.Yellow);
+            }
+        "#)
+        .test();
+}


### PR DESCRIPTION
Fixes #31. This is a very basic version of C-Style enum support. 

Some limitations are:
* Since they are C-Style, they are only represented as numbers in JS and cannot have associated data
* The number representation is hardcoded to be in order starting at 0.
*  If functions that take these enums as arguments are not given a number that can be translated to the enum, the JS throws an error. 

All these limitations should be fairly easy to overcome, but I wanted to get this reviewed sooner rather than later since I'm new to the codebase. If this is merged, I can work on fixing the limitations (especially the first two).

I wasn't sure if this was the best way to structure the code, so feedback is very welcome :-D