### PR TITLE
Add section on node dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,3 +439,8 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
+
+### Tests
+
+In order to run the tests you will need (node.js)[https://nodejs.org/] version
+8.9.4 or above. Running the tests is done by running `cargo test`.


### PR DESCRIPTION
The tests were failing to run for me because my version of node was old (7.2.1). Version 8.9.4 is the latest LTS version of nodejs.org. I verified the tests run with this version and version 9.6.1 - the latest version.