### PR TITLE
Enable returning a vector of js values

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ are:
 * Imported types in a foreign module annotated with `#[wasm_bindgen]`
 * Borrowed exported structs (`&Foo` or `&mut Bar`)
 * The `JsValue` type and `&JsValue` (not mutable references)
-* Vectors and slices of supported integer types
+* Vectors and slices of supported integer types and of the `JsValue` type.
 
 All of the above can also be returned except borrowed references. Strings are
 implemented with shim functions to copy data in/out of the Rust heap. That is, a

--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ are:
 * The `JsValue` type and `&JsValue` (not mutable references)
 * Vectors and slices of supported integer types and of the `JsValue` type.
 
-All of the above can also be returned except borrowed references. Strings are
+All of the above can also be returned except borrowed references. Passing
+`Vec<JsValue>` as an argument to a function is not currently supported. Strings are
 implemented with shim functions to copy data in/out of the Rust heap. That is, a
 string passed to Rust from JS is copied to the Rust heap (using a generated shim
 to malloc some space) and then will be freed appropriately.

--- a/crates/wasm-bindgen-cli-support/src/js.rs
+++ b/crates/wasm-bindgen-cli-support/src/js.rs
@@ -660,12 +660,12 @@ impl<'a> Context<'a> {
         if !self.exposed_globals.insert("get_array_js_value_from_wasm") {
             return
         }
-        self.expose_get_array_u8_from_wasm();
+        self.expose_get_array_u32_from_wasm();
         self.expose_get_object();
         self.globals.push_str(&format!("
                 function getArrayJsValueFromWasm(ptr, len) {{
-                    const mem = getUint8Memory();
-                    const slice = mem.slice(ptr, ptr + len);
+                    const mem = getUint32Memory();
+                    const slice = mem.slice(ptr / 4, ptr / 4 + len);
                     const result = []
                     for (ptr in slice) {{
                         result.push(getObject(ptr))
@@ -1569,7 +1569,7 @@ impl VectorType {
             VectorKind::U32 => "Uint32Array",
             VectorKind::F32 => "Float32Array",
             VectorKind::F64 => "Float64Array",
-            VectorKind::JsValue => "object[]",
+            VectorKind::JsValue => "any[]",
         }
     }
 }

--- a/crates/wasm-bindgen-macro/src/ast.rs
+++ b/crates/wasm-bindgen-macro/src/ast.rs
@@ -72,6 +72,7 @@ pub enum VectorType {
     U32,
     F32,
     F64,
+    JsValue,
 }
 
 impl Program {
@@ -544,6 +545,8 @@ impl Type {
             Type::Vector(VectorType::F32, false) => a.char(shared::TYPE_SLICE_F32),
             Type::Vector(VectorType::F64, true) => a.char(shared::TYPE_VECTOR_F64),
             Type::Vector(VectorType::F64, false) => a.char(shared::TYPE_SLICE_F64),
+            Type::Vector(VectorType::JsValue, true) => a.char(shared::TYPE_VECTOR_JSVALUE),
+            Type::Vector(VectorType::JsValue, false) => panic!("Slices of JsValues not supported"),
             Type::ByValue(ref t) => {
                 a.as_char(my_quote! {
                     <#t as ::wasm_bindgen::convert::WasmBoundary>::DESCRIPTOR
@@ -978,6 +981,7 @@ impl VectorType {
             "u32" => Some(VectorType::U32),
             "f32" => Some(VectorType::F32),
             "f64" => Some(VectorType::F64),
+            "JsValue" => Some(VectorType::JsValue),
             _ => None,
         }
     }
@@ -993,6 +997,7 @@ impl VectorType {
             VectorType::U32 => syn::Ident::from("u32"),
             VectorType::F32 => syn::Ident::from("f32"),
             VectorType::F64 => syn::Ident::from("f64"),
+            VectorType::JsValue => syn::Ident::from("JsValue"),
         }
     }
 }
@@ -1009,6 +1014,7 @@ impl ToTokens for VectorType {
             VectorType::U32 => my_quote! { Vec<u32> },
             VectorType::F32 => my_quote! { Vec<f32> },
             VectorType::F64 => my_quote! { Vec<f64> },
+            VectorType::JsValue => my_quote! { Vec<JsValue> },
         };
         me.to_tokens(tokens);
     }

--- a/crates/wasm-bindgen-shared/src/lib.rs
+++ b/crates/wasm-bindgen-shared/src/lib.rs
@@ -90,6 +90,8 @@ pub fn mangled_import_name(struct_: Option<&str>, f: &str) -> String {
 
 pub type Type = char;
 
+pub const TYPE_VECTOR_JSVALUE: char = '\u{5b}';
+// Note: '\u{5c}' is '\' which breaks json encoding/decoding
 pub const TYPE_ENUM: char = '\u{5d}';
 pub const TYPE_NUMBER: char = '\u{5e}';
 pub const TYPE_BORROWED_STR: char = '\u{5f}';

--- a/tests/jsobjects.rs
+++ b/tests/jsobjects.rs
@@ -176,3 +176,43 @@ fn promote() {
         "#)
         .test();
 }
+
+#[test]
+fn returning_vector() {
+    test_support::project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen(module = "./test")]
+            extern {
+                fn foo() -> JsValue;
+            }
+
+            #[wasm_bindgen]
+            #[no_mangle]
+            pub extern fn bar() -> Vec<JsValue> {
+                let mut res = Vec::new();
+                for _ in 0..10 {
+                    res.push(foo())
+                }
+                res
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as wasm from "./out";
+            import * as assert from "assert";
+
+
+            export function foo(): any { return { "foo": "bar" } }
+
+            export function test() {
+                const result = wasm.bar();
+                assert.strictEqual(result.length, 10);
+            }
+        "#)
+        .test();
+}

--- a/tests/jsobjects.rs
+++ b/tests/jsobjects.rs
@@ -206,8 +206,7 @@ fn returning_vector() {
             import * as wasm from "./out";
             import * as assert from "assert";
 
-
-            export function foo(): any { return { "foo": "bar" } }
+            export function foo(): any { return { "foo": "bar" }; }
 
             export function test() {
                 const result = wasm.bar();


### PR DESCRIPTION
Fixes #33 

@alexcrichton This continues with special casing vectors. Hopefully next we can find a general solution to vectors.