### PR TITLE
Add support for constructing JsValue instances generically

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -88,6 +88,7 @@ impl ToTokens for ast::Program {
 impl ToTokens for ast::Struct {
     fn to_tokens(&self, tokens: &mut Tokens) {
         let name = &self.name;
+        let new_fn = syn::Ident::from(shared::new_function(self.name.as_ref()));
         let free_fn = syn::Ident::from(shared::free_function(self.name.as_ref()));
         let c = shared::name_to_descriptor(name.as_ref());
         let descriptor = Literal::byte_string(format!("{:4}", c).as_bytes());
@@ -150,6 +151,21 @@ impl ToTokens for ast::Struct {
                     let js = js as *mut ::wasm_bindgen::__rt::WasmRefCell<#name>;
                     ::wasm_bindgen::__rt::assert_not_null(js);
                     (*js).borrow_mut()
+                }
+            }
+
+            impl ::std::convert::From<#name> for ::wasm_bindgen::JsValue {
+                fn from(value: #name) -> Self {
+                    let ptr = ::wasm_bindgen::convert::WasmBoundary::into_js(value);
+
+                    #[wasm_import_module = "__wbindgen_placeholder__"]
+                    extern {
+                        fn #new_fn(ptr: u32) -> u32;
+                    }
+
+                    unsafe {
+                        ::wasm_bindgen::JsValue::__from_idx(#new_fn(ptr))
+                    }
                 }
             }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -156,7 +156,10 @@ impl ToTokens for ast::Struct {
 
             impl ::std::convert::From<#name> for ::wasm_bindgen::JsValue {
                 fn from(value: #name) -> Self {
-                    let ptr = ::wasm_bindgen::convert::WasmBoundary::into_js(value);
+                    let ptr = ::wasm_bindgen::convert::WasmBoundary::into_abi(
+                        value,
+                        unsafe { &mut ::wasm_bindgen::convert::GlobalStack::new() },
+                    );
 
                     #[wasm_import_module = "__wbindgen_placeholder__"]
                     extern {
@@ -164,7 +167,11 @@ impl ToTokens for ast::Struct {
                     }
 
                     unsafe {
-                        ::wasm_bindgen::JsValue::__from_idx(#new_fn(ptr))
+                        <::wasm_bindgen::JsValue as ::wasm_bindgen::convert::WasmBoundary>
+                            ::from_abi(
+                                #new_fn(ptr),
+                                unsafe { &mut ::wasm_bindgen::convert::GlobalStack::new() },
+                            )
                     }
                 }
             }

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -267,10 +267,14 @@ impl<'a> Context<'a> {
                 "));
                 ts_dst.push_str("constructor(ptr: number, sym: Symbol);\n");
 
-                self.globals.push_str(&format!("
-                    export function {new_name}(ptr) {{
-                        return addHeapObject(new {class}(ptr, token));
-                    }}", new_name=shared::new_function(&class), class=class));
+                let new_name = shared::new_function(&class);
+                if self.wasm_import_needed(&new_name) {
+                    self.globals.push_str(&format!("
+                        export function {new_name}(ptr) {{
+                            return addHeapObject(new {class}(ptr, token));
+                        }}
+                    ", new_name = new_name, class = class));
+                }
             } else {
                 dst.push_str(&format!("
                     constructor(ptr) {{
@@ -279,10 +283,14 @@ impl<'a> Context<'a> {
                 "));
                 ts_dst.push_str("constructor(ptr: number);\n");
 
-                self.globals.push_str(&format!("
-                    export function {new_name}(ptr) {{
-                        return addHeapObject(new {class}(ptr));
-                    }}", new_name=shared::new_function(&class), class=class));
+                let new_name = shared::new_function(&class);
+                if self.wasm_import_needed(&new_name) {
+                    self.globals.push_str(&format!("
+                        export function {new_name}(ptr) {{
+                            return addHeapObject(new {class}(ptr));
+                        }}
+                    ", new_name = new_name, class = class));
+                }
             }
 
             dst.push_str(&format!("

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -266,6 +266,11 @@ impl<'a> Context<'a> {
                     }}
                 "));
                 ts_dst.push_str("constructor(ptr: number, sym: Symbol);\n");
+
+                self.globals.push_str(&format!("
+                    export function {new_name}(ptr) {{
+                        return addHeapObject(new {class}(ptr, token));
+                    }}", new_name=shared::new_function(&class), class=class));
             } else {
                 dst.push_str(&format!("
                     constructor(ptr) {{
@@ -273,6 +278,11 @@ impl<'a> Context<'a> {
                     }}
                 "));
                 ts_dst.push_str("constructor(ptr: number);\n");
+
+                self.globals.push_str(&format!("
+                    export function {new_name}(ptr) {{
+                        return addHeapObject(new {class}(ptr));
+                    }}", new_name=shared::new_function(&class), class=class));
             }
 
             dst.push_str(&format!("

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -88,6 +88,15 @@ pub struct CustomTypeName {
     pub name: String,
 }
 
+pub fn new_function(struct_name: &str) -> String {
+    let mut name = format!("__wbg_");
+    name.extend(struct_name
+        .chars()
+        .flat_map(|s| s.to_lowercase()));
+    name.push_str("_new");
+    return name
+}
+
 pub fn free_function(struct_name: &str) -> String {
     let mut name = format!("__wbg_");
     name.extend(struct_name

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,10 @@ impl JsValue {
         }
     }
 
-    // #[doc(hidden)]
-    // pub fn __from_idx(idx: u32) -> JsValue {
-    //     JsValue { idx }
-    // }
+    #[doc(hidden)]
+    pub unsafe fn __from_idx(idx: u32) -> JsValue {
+        JsValue { idx }
+    }
     //
     // #[doc(hidden)]
     // pub fn __get_idx(&self) -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,10 @@ impl JsValue {
         }
     }
 
-    #[doc(hidden)]
-    pub unsafe fn __from_idx(idx: u32) -> JsValue {
-        JsValue { idx }
-    }
+    // #[doc(hidden)]
+    // pub unsafe fn __from_idx(idx: u32) -> JsValue {
+    //     JsValue { idx }
+    // }
     //
     // #[doc(hidden)]
     // pub fn __get_idx(&self) -> u32 {

--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -4,7 +4,7 @@ extern crate test_support;
 fn simple() {
     test_support::project()
         .file("src/lib.rs", r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -56,7 +56,7 @@ fn simple() {
 fn strings() {
     test_support::project()
         .file("src/lib.rs", r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -114,7 +114,7 @@ fn strings() {
 fn exceptions() {
     test_support::project()
         .file("src/lib.rs", r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -179,7 +179,7 @@ fn exceptions() {
 fn pass_one_to_another() {
     test_support::project()
         .file("src/lib.rs", r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -276,7 +276,7 @@ fn pass_into_js() {
 fn issue_27() {
     test_support::project()
         .file("src/lib.rs", r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/dependencies.rs
+++ b/tests/dependencies.rs
@@ -6,7 +6,7 @@ fn dependencies_work() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             extern crate wasm_bindgen;
             extern crate dependency;
             use wasm_bindgen::prelude::*;
@@ -51,7 +51,7 @@ fn dependencies_work() {
         .file(
             "vendor/dependency/src/lib.rs",
             r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
 

--- a/tests/non-debug.rs
+++ b/tests/non-debug.rs
@@ -5,7 +5,7 @@ fn works() {
     test_support::project()
         .debug(false)
         .file("src/lib.rs", r#"
-            #![feature(proc_macro, wasm_custom_section)]
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
 


### PR DESCRIPTION
This is one step in the direction of fixing #75.  The idea is that it should be possible to construct `JsValue`s from any Rust type so that we are able to eventually call generic callbacks such as `Promise.resolve` without having to round-trip through Javascript helper functions.
