### PR TITLE
Fix import TextDecoder in output for nodejs config

### DIFF
--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -645,7 +645,7 @@ impl<'a> Context<'a> {
         }
         if self.config.nodejs {
             self.globals.push_str(&format!("
-                const TextDecoder = require('util');
+                const TextDecoder = require('util').TextDecoder;
             "));
         } else if !self.config.browser {
             self.globals.push_str(&format!("


### PR DESCRIPTION
Quick typo fix. When compiling for --nodejs the output is incorrect for importing TextDecoder from Node util.